### PR TITLE
Adjust to breaking change in format_href in pybtex

### DIFF
--- a/src/pybtex_docutils/__init__.py
+++ b/src/pybtex_docutils/__init__.py
@@ -68,8 +68,8 @@ class Backend(BaseBackend):
         else:
             return text
 
-    def format_href(self, url: str, text: List[docutils.nodes.Node]
-                    ) -> List[docutils.nodes.Node]:
+    def format_href(self, url: str, text: List[docutils.nodes.Node],
+                    external: bool=False) -> List[docutils.nodes.Node]:
         node = docutils.nodes.reference('', '', *text, refuri=url)
         return [node]
 


### PR DESCRIPTION
`format_href` gained an extra parameter in
https://bitbucket.org/pybtex-devs/pybtex/commits/a362ec5ca4052da459761c15e298d99a643a2413

Docutils doesn't support target="_blank" (https://stackoverflow.com/questions/11716781/open-a-link-in-a-new-window-in-restructuredtext), so just ignore the argument to restore compatibility.